### PR TITLE
Fix case-sensitivity issue with !pronounce command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,12 +120,12 @@ if(SAY_COMMAND_PRONOUNCE) {
 			const removed = args[0].toLowerCase() == args[1].toLowerCase() || args[0].toLowerCase() == "remove";
 
 			if(removed) {
-				if(!pronunciation.delete(args[1])) {
+				if(!pronunciation.delete(args[1].toLowerCase())) {
 					console.log("Moderator "+user+" failed to removed unknown pronunciation of " + args[1]);
 					return;
 				}
 			} else {
-				pronunciation.set(args[0], args[1]);
+				pronunciation.set(args[0].toLowerCase(), args[1]);
 			}
 
 			const msg = removed ? "Moderator "+user+" removed pronunciation of; " + args[1] :


### PR DESCRIPTION
When a new pronounciation is added, it is turned into lowercase first, so comparison during audio generation considers them regardless of casing.