### PR TITLE
Add config option to ignore specific users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can monitor your character usage on the [AWS Billing and Cost Management, Bu
 - `SAY_CONCAT_TEXT` - Additional text used to concatenate the username and what the user wrote.
 - `SAY_COOLDOWN` - User-based cooldown, i.e., how often a user can use the say command (in seconds), 0 to disable cooldown. Note: Mods ignore cooldown.
 - `SAY_MAX_LENGTH` - What is the maximum amount of characters used in the say command, messages longer than this option will be ignored. (0 to disable limit)
+- `SAY_IGNORED_USERS` - Usernames whose messages will not trigger TTS.
 
 ## How to get AWS access key and secret
 

--- a/env_template
+++ b/env_template
@@ -31,3 +31,6 @@ SAY_MAX_LENGTH=0
 # Remove or comment out following line if you do not want to allow mods to modify pronunciation modifiers
 # Notice: all already written pronunciations in 'pronunciation.json' file will still be applied
 SAY_COMMAND_PRONOUNCE=!pronounce
+
+# Users whose messages will not trigger TTS
+SAY_IGNORED_USERS=Nightbot,WizeBot,StreamElements

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,12 +120,12 @@ if(SAY_COMMAND_PRONOUNCE) {
 			const removed = args[0].toLowerCase() == args[1].toLowerCase() || args[0].toLowerCase() == "remove";
 
 			if(removed) {
-				if(!pronunciation.delete(args[1])) {
+				if(!pronunciation.delete(args[1].toLowerCase())) {
 					console.log("Moderator "+user+" failed to removed unknown pronunciation of " + args[1]);
 					return;
 				}
 			} else {
-				pronunciation.set(args[0], args[1]);
+				pronunciation.set(args[0].toLowerCase(), args[1]);
 			}
 
 			const msg = removed ? "Moderator "+user+" removed pronunciation of; " + args[1] :

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ const SAY_CONCAT_TEXT = process.env.SAY_CONCAT_TEXT || "said";
 const SAY_DEFAULT_VOICE: VoiceId = (process.env.SAY_DEFAULT_VOICE as VoiceId) ?? "Brian";
 const SAY_COOLDOWN = process.env.SAY_COOLDOWN ? Number.parseInt(process.env.SAY_COOLDOWN) : undefined;
 const SAY_MAX_LENGTH = process.env.SAY_MAX_LENGTH ? Number.parseInt(process.env.SAY_MAX_LENGTH) : undefined;
+const SAY_IGNORED_USERS = process.env.SAY_IGNORED_USERS ? process.env.SAY_IGNORED_USERS.toLowerCase().split(",") : [];
 
 if(SAY_VOLUME > 2 || SAY_VOLUME < 0)
 	throw new Error("SAY_VOLUME must be number between 200 and 0");
@@ -83,9 +84,15 @@ chat.command({
 		if(!isModerator && SAY_MAX_LENGTH) {
 			if(message.length > SAY_MAX_LENGTH) {
 				console.log(`Ignoring TTS of '${user}' due to message length (${message.length} characters).`);
-					return false;
+				return false;
 			}
 		}
+
+		if(SAY_IGNORED_USERS.includes(user.toLowerCase())) {
+			console.log(`Ignoring TTS of '${user}' due to user being ignored in config file.`);
+			return false;
+		}
+
 		return !message.startsWith("!") && !message.startsWith("/");
 	},
 	onTrigger: async (user, message, isModerator) => {


### PR DESCRIPTION
Added SAY_IGNORED_USERS config option that contains a comma separated list of user names. Messages from these users will be ignored by the !say command.